### PR TITLE
feat: Improve twt error handling

### DIFF
--- a/lib/api.dart
+++ b/lib/api.dart
@@ -106,9 +106,6 @@ class Api {
   }
 
   Future<PagedResponse> discover(int page) async {
-    if (page == 2) {
-      throw Exception();
-    }
     final _user = await user;
     final response = await _httpClient.post(
       _user.profile.uri.replace(path: "/api/v1/discover"),

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -106,6 +106,9 @@ class Api {
   }
 
   Future<PagedResponse> discover(int page) async {
+    if (page == 2) {
+      throw Exception();
+    }
     final _user = await user;
     final response = await _httpClient.post(
       _user.profile.uri.replace(path: "/api/v1/discover"),

--- a/lib/screens/discover.dart
+++ b/lib/screens/discover.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:http/http.dart' as http;
 
 import '../widgets/common_widgets.dart';
 import '../viewmodels.dart';
@@ -8,41 +7,16 @@ import 'newtwt.dart';
 
 class Discover extends StatefulWidget {
   static const String routePath = '/discover';
+
   @override
   _DiscoverState createState() => _DiscoverState();
 }
 
 class _DiscoverState extends State<Discover> {
-  Future _fetchNewPostFuture;
   @override
   void initState() {
     super.initState();
-    _fetchNewPost();
-  }
-
-  void _page() async {
-    try {
-      await context.read<DiscoverViewModel>().gotoNextPage();
-    } on http.ClientException catch (e) {
-      Scaffold.of(context).showSnackBar(SnackBar(content: Text(e.message)));
-    } catch (e) {
-      print(e);
-    }
-  }
-
-  void _fetchNewPost() {
-    Future<void> _fetch() async {
-      try {
-        await context.read<DiscoverViewModel>().refreshPost();
-      } on http.ClientException catch (e) {
-        Scaffold.of(context).showSnackBar(SnackBar(content: Text(e.message)));
-        rethrow;
-      }
-    }
-
-    setState(() {
-      _fetchNewPostFuture = _fetch();
-    });
+    Future.microtask(() => context.read<DiscoverViewModel>().fetchNewPost());
   }
 
   @override
@@ -60,37 +34,37 @@ class _DiscoverState extends State<Discover> {
           onPressed: () async {
             if (await Navigator.push(
                   context,
-                  MaterialPageRoute(
-                    builder: (_) => NewTwt(),
-                  ),
+                  MaterialPageRoute(builder: (_) => NewTwt()),
                 ) ??
                 false) {
-              _fetchNewPost();
+              context.read<DiscoverViewModel>().fetchNewPost();
             }
           },
         ),
       ),
-      body: FutureBuilder(
-        future: _fetchNewPostFuture,
-        builder: (context, snapshot) {
-          return Consumer<DiscoverViewModel>(
-            builder: (context, discoverViewModel, _) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return Center(
-                  child: CircularProgressIndicator(),
-                );
-              }
+      body: Consumer<DiscoverViewModel>(
+        builder: (context, vm, _) {
+          switch (vm.mainListState) {
+            case FetchState.Loading:
+              return Center(child: CircularProgressIndicator());
+            case FetchState.Error:
+              return ErrorMessage(
+                buttonLabel: 'Tap to retry',
+                description: 'An unexpected has occurred',
+                onRetryPressed: vm.fetchNewPost,
+              );
+
+            default:
               return RefreshIndicator(
-                onRefresh: discoverViewModel.refreshPost,
+                onRefresh: vm.refreshPost,
                 child: PostList(
-                  isBottomListLoading: discoverViewModel.isBottomListLoading,
-                  gotoNextPage: _page,
-                  fetchNewPost: _fetchNewPost,
-                  twts: discoverViewModel.twts,
+                  gotoNextPage: vm.gotoNextPage,
+                  fetchNewPost: vm.fetchNewPost,
+                  fetchMoreState: vm.fetchMoreState,
+                  twts: vm.twts,
                 ),
               );
-            },
-          );
+          }
         },
       ),
     );

--- a/lib/screens/discover.dart
+++ b/lib/screens/discover.dart
@@ -48,9 +48,7 @@ class _DiscoverState extends State<Discover> {
             case FetchState.Loading:
               return Center(child: CircularProgressIndicator());
             case FetchState.Error:
-              return ErrorMessage(
-                buttonLabel: 'Tap to retry',
-                description: 'An unexpected has occurred',
+              return UnexpectedErrorMessage(
                 onRetryPressed: vm.fetchNewPost,
               );
 

--- a/lib/screens/profile.dart
+++ b/lib/screens/profile.dart
@@ -5,7 +5,6 @@ import 'package:url_launcher/url_launcher.dart';
 import '../widgets/common_widgets.dart';
 import '../models.dart';
 import '../viewmodels.dart';
-import 'package:http/http.dart' as http;
 
 import 'newtwt.dart';
 

--- a/lib/screens/profile.dart
+++ b/lib/screens/profile.dart
@@ -356,7 +356,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
           ),
           body: PostList(
-            isBottomListLoading: profileViewModel.isBottomListLoading,
+            // isBottomListLoading: profileViewModel.isBottomListLoading,
             gotoNextPage: () => _page(context),
             fetchNewPost: profileViewModel.refreshPost,
             twts: profileViewModel.twts,

--- a/lib/screens/timeline.dart
+++ b/lib/screens/timeline.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:http/http.dart' as http;
 
 import '../widgets/common_widgets.dart';
 import '../viewmodels.dart';
@@ -16,24 +15,7 @@ class _TimelineState extends State<Timeline> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(() => _fetchNewPost());
-  }
-
-  void _page() async {
-    try {
-      context.read<TimelineViewModel>().gotoNextPage();
-    } on http.ClientException catch (e) {
-      Scaffold.of(context).showSnackBar(SnackBar(content: Text(e.message)));
-      rethrow;
-    }
-  }
-
-  void _fetchNewPost() async {
-    try {
-      context.read<TimelineViewModel>().fetchNewPost();
-    } on http.ClientException catch (e) {
-      Scaffold.of(context).showSnackBar(SnackBar(content: Text(e.message)));
-    }
+    Future.microtask(() => context.read<TimelineViewModel>().fetchNewPost());
   }
 
   @override
@@ -51,9 +33,7 @@ class _TimelineState extends State<Timeline> {
           onPressed: () async {
             if (await Navigator.push(
                   context,
-                  MaterialPageRoute(
-                    builder: (_) => NewTwt(),
-                  ),
+                  MaterialPageRoute(builder: (_) => NewTwt()),
                 ) ??
                 false) {
               context.read<TimelineViewModel>().fetchNewPost();
@@ -62,22 +42,27 @@ class _TimelineState extends State<Timeline> {
         ),
       ),
       body: Consumer<TimelineViewModel>(
-        builder: (context, timelineViewModel, _) {
-          if (timelineViewModel.isEntireListLoading) {
-            return Center(
-              child: CircularProgressIndicator(),
-            );
+        builder: (context, vm, _) {
+          switch (vm.mainListState) {
+            case FetchState.Loading:
+              return Center(child: CircularProgressIndicator());
+            case FetchState.Error:
+              return ErrorMessage(
+                buttonLabel: 'Tap to retry',
+                description: 'An unexpected has occurred',
+                onRetryPressed: vm.gotoNextPage,
+              );
+            default:
+              return RefreshIndicator(
+                onRefresh: vm.refreshPost,
+                child: PostList(
+                  gotoNextPage: vm.gotoNextPage,
+                  fetchNewPost: vm.fetchNewPost,
+                  fetchMoreState: vm.fetchMoreState,
+                  twts: vm.twts,
+                ),
+              );
           }
-
-          return RefreshIndicator(
-            onRefresh: timelineViewModel.refreshPost,
-            child: PostList(
-              isBottomListLoading: timelineViewModel.isBottomListLoading,
-              gotoNextPage: _page,
-              fetchNewPost: timelineViewModel.fetchNewPost,
-              twts: timelineViewModel.twts,
-            ),
-          );
         },
       ),
     );

--- a/lib/screens/timeline.dart
+++ b/lib/screens/timeline.dart
@@ -47,9 +47,7 @@ class _TimelineState extends State<Timeline> {
             case FetchState.Loading:
               return Center(child: CircularProgressIndicator());
             case FetchState.Error:
-              return ErrorMessage(
-                buttonLabel: 'Tap to retry',
-                description: 'An unexpected has occurred',
+              return UnexpectedErrorMessage(
                 onRetryPressed: vm.gotoNextPage,
               );
             default:

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -15,4 +15,7 @@ class AppStrings {
 
   String failLaunch = 'Failed to launch';
   String failLaunchImageToBrowser = 'Failed to launch image in browser';
+
+  String unexpectedError = 'An unexpected error has occurred';
+  String tapToRetry = 'Tap to retry';
 }

--- a/lib/viewmodels.dart
+++ b/lib/viewmodels.dart
@@ -100,6 +100,7 @@ class TimelineViewModel extends ChangeNotifier {
       mainListState = FetchState.Done;
     } catch (e) {
       mainListState = FetchState.Error;
+      rethrow;
     }
   }
 
@@ -117,6 +118,7 @@ class TimelineViewModel extends ChangeNotifier {
       fetchMoreState = FetchState.Done;
     } catch (e) {
       fetchMoreState = FetchState.Error;
+      rethrow;
     }
   }
 }
@@ -161,6 +163,7 @@ class DiscoverViewModel extends ChangeNotifier {
       mainListState = FetchState.Done;
     } catch (e) {
       mainListState = FetchState.Error;
+      rethrow;
     }
   }
 
@@ -171,7 +174,6 @@ class DiscoverViewModel extends ChangeNotifier {
     }
 
     fetchMoreState = FetchState.Loading;
-    await Future.delayed(Duration(seconds: 5));
     try {
       final page = _lastTimelineResponse.pagerResponse.currentPage + 1;
       _lastTimelineResponse = await _api.discover(page);
@@ -179,6 +181,7 @@ class DiscoverViewModel extends ChangeNotifier {
       fetchMoreState = FetchState.Done;
     } catch (e) {
       fetchMoreState = FetchState.Error;
+      rethrow;
     }
   }
 }
@@ -208,7 +211,6 @@ class ProfileViewModel extends ChangeNotifier {
   PagedResponse _lastTimelineResponse;
   List<Twt> _twts = [];
 
-  FetchState _mainListState = FetchState.Done;
   FetchState _fetchMoreState = FetchState.Done;
 
   List<Twt> get twts => _twts;
@@ -277,11 +279,10 @@ class ProfileViewModel extends ChangeNotifier {
       final page = _lastTimelineResponse.pagerResponse.currentPage + 1;
       _lastTimelineResponse = await _api.getUserTwts(page, profile.username);
       _twts = [..._twts, ..._lastTimelineResponse.twts];
+      fetchMoreState = FetchState.Done;
     } catch (e) {
       fetchMoreState = FetchState.Error;
-      return;
-    } finally {
-      fetchMoreState = FetchState.Done;
+      rethrow;
     }
   }
 }

--- a/lib/widgets/common_widgets.dart
+++ b/lib/widgets/common_widgets.dart
@@ -189,15 +189,15 @@ class PostList extends StatefulWidget {
     @required this.fetchNewPost,
     @required this.gotoNextPage,
     @required this.twts,
-    @required this.isBottomListLoading,
+    @required this.fetchMoreState,
     this.topSlivers = const <Widget>[],
   }) : super(key: key);
 
   final Function fetchNewPost;
   final Function gotoNextPage;
-  final bool isBottomListLoading;
   final List<Twt> twts;
   final List<Widget> topSlivers;
+  final FetchState fetchMoreState;
 
   @override
   _PostListState createState() => _PostListState();
@@ -214,8 +214,7 @@ class _PostListState extends State<PostList> {
 
   void initiateLoadMoreOnScroll() {
     if (_scrollController.position.pixels >
-            _scrollController.position.maxScrollExtent * 0.9 &&
-        !widget.isBottomListLoading) {
+        _scrollController.position.maxScrollExtent * 0.9) {
       widget.gotoNextPage();
     }
   }
@@ -425,7 +424,7 @@ class _PostListState extends State<PostList> {
             childCount: widget.twts.length,
           ),
         ),
-        if (widget.isBottomListLoading)
+        if (widget.fetchMoreState == FetchState.Loading)
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 64.0),
@@ -435,6 +434,36 @@ class _PostListState extends State<PostList> {
             ),
           )
       ],
+    );
+  }
+}
+
+class ErrorMessage extends StatelessWidget {
+  final VoidCallback onRetryPressed;
+  final String description;
+  final String buttonLabel;
+  const ErrorMessage({
+    Key key,
+    this.onRetryPressed,
+    this.buttonLabel,
+    this.description,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(description),
+          SizedBox(height: 32),
+          RaisedButton(
+            color: Theme.of(context).colorScheme.error,
+            onPressed: onRetryPressed,
+            child: Text(buttonLabel),
+          )
+        ],
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+17
+version: 1.0.0+18
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
### Changes
- Improve error handling when fetching twts. Closes #19 
- Use changenotifier instead of FutureBuilder for fetching + displaying twts

### Proof of performance
On error
![Peek 2020-09-26 19-21](https://user-images.githubusercontent.com/15314237/94353476-b6c82e00-002e-11eb-9e24-54b6283260f2.gif)

After tapping the "Tap to retry button"
![Peek 2020-09-26 19-26](https://user-images.githubusercontent.com/15314237/94353475-b5970100-002e-11eb-8c5a-690c1414c689.gif)