### PR TITLE
Improve dark mode switching perf

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,14 +18,17 @@ void main() async {
   final prefs = await SharedPreferences.getInstance();
 
   runApp(
-    ChangeNotifierProvider(
-      create: (context) => ThemeViewModel(prefs),
-      child: MyApp(),
+    MyApp(
+      sharedPreferences: prefs,
     ),
   );
 }
 
 class MyApp extends StatelessWidget {
+  final SharedPreferences sharedPreferences;
+
+  const MyApp({Key key, this.sharedPreferences}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     final api = Api(http.Client(), FlutterSecureStorage());
@@ -35,6 +38,9 @@ class MyApp extends StatelessWidget {
         Provider.value(value: api),
         Provider(create: (_) => AppStrings()),
         Provider(create: (_) => AuthViewModel(api)),
+        ChangeNotifierProvider(
+          create: (context) => ThemeViewModel(sharedPreferences),
+        ),
       ],
       child: AuthWidgetBuilder(
         builder: (context, snapshot) => MaterialApp(
@@ -54,6 +60,18 @@ class MyApp extends StatelessWidget {
                   color: Colors.white,
                   fontWeight: FontWeight.bold,
                 ),
+              ),
+            ),
+            inputDecorationTheme: InputDecorationTheme(
+              floatingLabelBehavior: FloatingLabelBehavior.never,
+              focusedBorder: UnderlineInputBorder(
+                borderSide: BorderSide(color: Colors.blue),
+              ),
+            ),
+            buttonTheme: ButtonThemeData(
+              textTheme: ButtonTextTheme.primary,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
               ),
             ),
           ),

--- a/lib/widgets/common_widgets.dart
+++ b/lib/widgets/common_widgets.dart
@@ -174,7 +174,8 @@ class AppDrawer extends StatelessWidget {
           buildListTile(context, 'Mentions', Mentions.routePath),
           SwitchListTile(
             title: Text("Dark mode"),
-            value: themeVM.isDarkModeEnabled,
+            value: themeVM.isDarkModeEnabled &&
+                Theme.of(context).brightness == Brightness.dark,
             onChanged: themeVM.toggleDarkMode,
           ),
           ListTile(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+21
+version: 1.0.0+22
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
- Move the ThemeViewModel change notifier to the multi provider, so that it wont rebuild the whole widget tree when switching themes. 