### PR TITLE
fix: appbar brightness

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,6 +51,7 @@ class MyApp extends StatelessWidget {
             brightness: Brightness.dark,
             accentColor: Colors.blue,
             appBarTheme: AppBarTheme(
+              brightness: Brightness.dark,
               elevation: 0,
               color: Colors.grey[850],
               iconTheme: IconThemeData(color: Colors.white),
@@ -78,6 +79,7 @@ class MyApp extends StatelessWidget {
           theme: ThemeData(
             brightness: Brightness.light,
             appBarTheme: AppBarTheme(
+              brightness: Brightness.light,
               elevation: 0,
               color: Colors.grey[50],
               iconTheme: IconThemeData(color: Colors.black),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+25
+version: 1.0.0+26
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Before the status bar is white when the them mode is set to light
![Screenshot from 2020-10-07 19-28-25](https://user-images.githubusercontent.com/15314237/95404900-8bb5c800-08d3-11eb-8a0b-c495ab243c47.png)

Now, it uses the dark text in the status bar so that it's readable
![Screenshot from 2020-10-07 19-28-36](https://user-images.githubusercontent.com/15314237/95404933-9bcda780-08d3-11eb-8be9-c54c8cea8bcd.png)

The solution is to pass the `brightness` prop to the appbar theme, so that the status bar adapts to the theme 

Here's the Brightness enum doc
```dart
/// Describes the contrast of a theme or color palette.
enum Brightness {
  /// The color is dark and will require a light text color to achieve readable
  /// contrast.
  ///
  /// For example, the color might be dark grey, requiring white text.
  dark,

  /// The color is light and will require a dark text color to achieve readable
  /// contrast.
  ///
  /// For example, the color might be bright white, requiring black text.
  light,
}
}
```

fixes #38 
